### PR TITLE
Fixed #5: Trying to use mongo export result

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function (opts) {
     if (content[0] === '[') {
       // Assume file contains properly formatted JSON array
       try {
-        json = JSON.parse(content)
+        json = json2mongo(JSON.parse(content))
       } catch (e) {
         return cb(
           new PluginError(


### PR DESCRIPTION
$oid can be used inside a json array file exported from `mongoexport` command with `--jsonArray` parameter